### PR TITLE
Fix typo in readme: note-in instead of note-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ it's binding for [vstplugin](https://github.com/Spacechild1/vstplugin).
 (defparameter *piano* (sc-vst:vst-controller (synth 'piano) :piano "Pianoteq 7"))
 (sc-vst:editor *piano*)
 
-(sc-vst::note-in *piano* 1 50 100)
+(sc-vst::note-on *piano* 1 50 100)
 (sc-vst::note-off *piano* 1 50 100)
 ```
 


### PR DESCRIPTION
Hi,

Thank you for this library, i just started learning CL after some time trying to get familiar with SC.
I had trouble getting into sclang so cl-collider and sc-synth are very motivating.

I managed to get the example in the readme working, substituting Valhalla and Pianoteq with Surge and fixing this typo in `note-on`.

```lisp

(defparameter *reverb* (sc-vst:vst-controller (synth 'surge-reverb) :reverb "Surge XT Effects.vst3"))

(sc-vst:editor *reverb*)
(sc-vst:parameter-list *reverb*)

(sc-vst:parameter *reverb* 0)
(setf (sc-vst:parameter *reverb* 0) 0.5)
(defsynth piano ()
  (out.ar 0 (sc-vst:vst-plugin.ar nil 2 :piano)))

(defparameter *piano* (sc-vst:vst-controller (synth 'piano) :piano "Surge XT.vst3"))
(sc-vst:editor *piano*)

(sc-vst::note-on *piano* 1 50 100)
(sc-vst::note-off *piano* 1 50 100)
```